### PR TITLE
Stable logging with formatting adjustments

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -93,19 +93,19 @@ def printEngineFuel(raw_data, screen):
     # data
     engine_fuel_front = (raw_data[22] << 8 | raw_data[21]) * 0.00133  # Fuel Pulsewidth in ms
     engine_fuel_rear = (raw_data[24] << 8 | raw_data[23]) * 0.00133  # Fuel Pulsewidth in ms
-    formatted_output = f'Fuel Millis: F: {engine_fuel_front :{padding}>{width}.2f} ms | R: {engine_fuel_rear :{padding}>{width}.2f} ms'
+    formatted_output = f'FPW: F {engine_fuel_front :{padding}>{width}.2f} R {engine_fuel_rear :{padding}>{width}.2f}'
 
     screen.addstr(location[1], location[0], formatted_output)
 
     # readout in fuel table value
     padding = ' '
-    width = 3
+    width = 5
     location = (0, 3)  # x, y
 
     # data
-    engine_fuel_front = (raw_data[18] << 8 | raw_data[17]) * 0.026666  # fuel table reading
-    engine_fuel_rear = (raw_data[20] << 8 | raw_data[19]) * 0.026666  # fuel table reading
-    formatted_output = f'Fuel Table: F: {engine_fuel_front :{padding}>{width}.0f} | R: {engine_fuel_rear :{padding}>{width}.0f}'
+    engine_fuel_front = (raw_data[18] << 8 | raw_data[17]) * 0.026666  # fuel table value
+    engine_fuel_rear = (raw_data[20] << 8 | raw_data[19]) * 0.026666  # fuel table value
+    formatted_output = f'FTB: F {engine_fuel_front :{padding}>{width}.0f} R {engine_fuel_rear :{padding}>{width}.0f}'
 
     screen.addstr(location[1], location[0], formatted_output)
 
@@ -117,7 +117,7 @@ def printBatteryVoltage(raw_data, screen):
 
     # data
     engine_volts = (raw_data[29] << 8 | raw_data[28]) * 0.01  # battery voltage
-    formatted_output = f'Battery: {engine_volts :{padding}>{width}.2f} v'
+    formatted_output = f'Batt V: {engine_volts :{padding}>{width}.2f}'
 
     screen.addstr(location[1], location[0], formatted_output)
 
@@ -130,7 +130,7 @@ def printEngineTimingAdvance(raw_data, screen):
     # data
     engine_timing_front = (raw_data[14] << 8 | raw_data[13]) * 0.0025  # degrees of spark advance
     engine_timing_rear = (raw_data[16] << 8 | raw_data[15]) * 0.0025  # degrees of spark advance
-    formatted_output = f'Advance: F: {engine_timing_front :{padding}>{width}.2f} * | R: {engine_timing_rear :{padding}>{width}.2f} *'
+    formatted_output = f'Adv: F {engine_timing_front :{padding}>{width}.2f} R {engine_timing_rear :{padding}>{width}.2f}'
 
     screen.addstr(location[1], location[0], formatted_output)
 

--- a/logger.py
+++ b/logger.py
@@ -180,7 +180,6 @@ def main(screen, *args):
         else:
             # draw it out
             printEngineTempAndO2(data, screen)
-            #printEngineO2(data, screen)
             printEngineFuel(data, screen)
             printBatteryVoltage(data, screen)
             printEngineTimingAdvance(data, screen)
@@ -191,10 +190,6 @@ def main(screen, *args):
 
         # refresh the screen
         screen.refresh()
-
-        # add a delay here as needed, so we don't overwhelm the ECM if anything
-         # we already have a delay in getRuntimeData() itself, no real need to add to it
-        # sleep(0.25)
 
 
 # basically a main() wrapper to cleanly init and de-init curses

--- a/logger.py
+++ b/logger.py
@@ -21,9 +21,6 @@ runtime_data_header = [
 
 RTD_BYTES = bytearray(runtime_data_header)
 
-# globals
-RECORD_INCREMENT = 0
-
 
 # test with:
 # curses.wrapper(sample)
@@ -49,12 +46,17 @@ def getRuntimeData(serial_device):
 
 
 def recordData(raw_data, file_obj):
-    global RECORD_INCREMENT
-
-    RECORD_INCREMENT = RECORD_INCREMENT + 160  # approximation of what the log record field should contain
-
     file_obj.write(raw_data)
-    file_obj.write(RECORD_INCREMENT.to_bytes(4, "big"))
+
+    # this emulates the record separator in a Megasquirt-style binary log.
+    # usually its an incremental time-ish based record, but I haven't been
+    # able to identify what this needs to be exactly. leaving it blank
+    # works fine with MegaLogViewer and EcmSpy's log analyzer, it just
+    # skews the runtime in MegaLogViewer, which might be fine.
+    file_obj.write(int(0).to_bytes(4, "big"))  # b'\x00\x00\x00\x00'
+
+    # making sure to flush anything in the buffer so we don't lose anything
+    # when we abruptly turn the bike off
     file_obj.flush()
 
 


### PR DESCRIPTION
- Add formatting adjustments for a 20x7 screen layout
- Adjust sleep interval to gather data a bit quicker
- Add log header for MegaLogViewer and EcmSpy-compatible logging output
- Minor clean up of unused code and old comments

I'll probably integrate the checksum checks on each log record with the next iteration so we can gracefully manage what we do with bad data instead of collecting everything and then having to filter it out later.